### PR TITLE
Add environment variable support and email sender configuration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+DEFAULT_EMAIL_SENDER="Example Name <hello@example.com>"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ target/
 
 *.sqlite
 *.sqlite-*
+
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,12 +141,13 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "appointments"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "axum",
  "chrono",
  "chrono-tz 0.10.0",
+ "dotenvy",
  "fluent-templates",
  "include_dir",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appointments"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 default-run = "appointments-cli"
@@ -25,6 +25,7 @@ async-trait = { version = "0.1.74" }
 axum = { version = "0.8.1" }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = { version = "0.10.0", features = ["serde"] }
+dotenvy = "0.15.7"
 # view engine i18n
 fluent-templates = { version = "0.8.0", features = ["tera"] }
 include_dir = { version = "0.7" }

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -106,3 +106,6 @@ auth:
     secret: TnYEuav3m16TdSdgAPSD
     # Token expiration time in seconds
     expiration: 604800 # 7 days
+
+settings:
+  default_email_sender: {{ get_env(name="DEFAULT_EMAIL_SENDER", default="example@example.com") }}

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -59,16 +59,16 @@ mailer:
   # SMTP mailer configuration.
   smtp:
     # Enable/Disable smtp mailer.
-    enable: false
+    enable: true
     # SMTP server host. e.x localhost, smtp.gmail.com
-    host: localhost
+    host: {{ get_env(name="SMTP_HOST", default="localhost") }}
     # SMTP server port
-    port: 1025
+    port: {{ get_env(name="SMTP_PORT", default="1025") }}
     # Use secure connection (SSL/TLS).
-    secure: false
-    # auth:
-    #   user:
-    #   password:
+    secure: true
+    auth:
+      user: {{ get_env(name="SMTP_USER", default="") }}
+      password: {{ get_env(name="SMTP_PASSWORD", default="") }}
     # Override the SMTP hello name (default is the machine's hostname)
     # hello_name:
 
@@ -108,3 +108,6 @@ auth:
     secret: {{ get_env(name="JWT_SECRET", default="") }}
     # Token expiration time in seconds
     expiration: 604800 # 7 days
+
+settings:
+  default_email_sender: {{ get_env(name="DEFAULT_EMAIL_SENDER", default="") }}

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,9 +45,10 @@ impl Hooks for App {
     }
 
     async fn initializers(_ctx: &AppContext) -> Result<Vec<Box<dyn Initializer>>> {
-        Ok(vec![Box::new(
-            initializers::admin_settings::AdminSettingsInitializer,
-        )])
+        Ok(vec![
+            Box::new(initializers::env_vars::EnvVarsInitializer),
+            Box::new(initializers::admin_settings::AdminSettingsInitializer),
+        ])
     }
 
     fn routes(ctx: &AppContext) -> AppRoutes {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod settings;

--- a/src/common/settings.rs
+++ b/src/common/settings.rs
@@ -1,0 +1,13 @@
+use loco_rs::prelude::*;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    pub default_email_sender: String,
+}
+
+impl Settings {
+    pub fn from_json(value: &serde_json::Value) -> Result<Self> {
+        Ok(serde_json::from_value(value.clone())?)
+    }
+}

--- a/src/initializers/env_vars.rs
+++ b/src/initializers/env_vars.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+use loco_rs::{environment::Environment, prelude::*};
+
+pub struct EnvVarsInitializer;
+
+#[async_trait]
+impl Initializer for EnvVarsInitializer {
+    fn name(&self) -> String {
+        "env-vars".to_string()
+    }
+
+    async fn before_run(&self, ctx: &AppContext) -> Result<()> {
+        let filename = match ctx.environment {
+            Environment::Production => ".env",
+            _ => ".env.development",
+        };
+
+        if dotenvy::from_filename(filename).is_ok() {
+            tracing::info!("{filename} loaded!");
+        } else {
+            tracing::warn!("{filename} file not found!");
+        }
+
+        Ok(())
+    }
+}

--- a/src/initializers/mod.rs
+++ b/src/initializers/mod.rs
@@ -1,1 +1,2 @@
 pub mod admin_settings;
+pub mod env_vars;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_errors_doc)]
 
 pub mod app;
+pub mod common;
 pub mod controllers;
 pub mod extractors;
 pub mod initializers;

--- a/src/mailers/appointments.rs
+++ b/src/mailers/appointments.rs
@@ -13,7 +13,14 @@ static notify_client: Dir<'_> = include_dir!("src/mailers/appointments/notify_cl
 
 #[allow(clippy::module_name_repetitions)]
 pub struct AppointmentsMailer {}
-impl Mailer for AppointmentsMailer {}
+impl Mailer for AppointmentsMailer {
+    fn opts() -> mailer::MailerOpts {
+        mailer::MailerOpts {
+            from: std::env::var("DEFAULT_EMAIL_SENDER").unwrap(),
+            ..Default::default()
+        }
+    }
+}
 impl AppointmentsMailer {
     /// Send an email
     ///

--- a/src/mailers/auth.rs
+++ b/src/mailers/auth.rs
@@ -1,10 +1,9 @@
 // auth mailer
 #![allow(non_upper_case_globals)]
 
-use loco_rs::{environment::Environment, prelude::*};
-use serde_json::json;
-
 use crate::models::users;
+use loco_rs::{environment::Environment, mailer::MailerOpts, prelude::*};
+use serde_json::json;
 
 static welcome: Dir<'_> = include_dir!("src/mailers/auth/welcome");
 static forgot: Dir<'_> = include_dir!("src/mailers/auth/forgot");
@@ -12,7 +11,14 @@ static magic_link: Dir<'_> = include_dir!("src/mailers/auth/magic_link");
 
 #[allow(clippy::module_name_repetitions)]
 pub struct AuthMailer {}
-impl Mailer for AuthMailer {}
+impl Mailer for AuthMailer {
+    fn opts() -> MailerOpts {
+        MailerOpts {
+            from: dotenvy::var("DEFAULT_EMAIL_SENDER").unwrap(),
+            ..Default::default()
+        }
+    }
+}
 impl AuthMailer {
     fn host(ctx: &AppContext) -> String {
         match ctx.environment {


### PR DESCRIPTION
- Load .env files via dotenvy initializer 
- Add DEFAULT_EMAIL_SENDER setting to config files 
- Use environment variables in mailer implementations 
- Bump version to 0.1.1